### PR TITLE
Update migrate_to_9336.adoc

### DIFF
--- a/switch-cisco-9336c-fx2/migrate_to_9336.adoc
+++ b/switch-cisco-9336c-fx2/migrate_to_9336.adoc
@@ -185,7 +185,7 @@ cs2(config-if-range)# *shutdown*
 +
 [subs=+quotes]
 ----
-cluster1::*> *network interface show -vserver cluster*
+cluster1::*> *network interface show -vserver Cluster*
             Logical       Status     Network            Current    Current Is
 Vserver     Interface     Admin/Oper Address/Mask       Node       Port    Home
 ----------- ------------- ---------- ------------------ ---------- ------- ----
@@ -275,7 +275,7 @@ few seconds: `network interface show -vserver Cluster`
 +
 [subs=+quotes]
 ----
-cluster1::*> *network interface show -vserver cluster*
+cluster1::*> *network interface show -vserver Cluster*
             Logical      Status     Network            Current     Current Is
 Vserver     Interfac     Admin/Oper Address/Mask       Node        Port    Home
 ----------- ------------ ---------- ------------------ ----------- ------- ----


### PR DESCRIPTION
Corrected syntax of 

-vserver cluster

to 

-vserver Cluster

For two different examples in steps 8 and 15.